### PR TITLE
Change from alias to item name

### DIFF
--- a/src/Commands/BuildValidation.php
+++ b/src/Commands/BuildValidation.php
@@ -14,7 +14,7 @@ trait BuildValidation
             if (!preg_match('/^\[/m',$item['validation'])) {
                 $item['validation'] = "'{$item['validation']}'";
             }
-            $validation .= $this->prefix("'{$field}' => {$item['validation']},", 3, true);
+            $validation .= $this->prefix("'{$item['name']}' => {$item['validation']},", 3, true);
         }
 
         return $validation;

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -117,13 +117,13 @@ class MigrationMakeCommand extends ExtendedGeneratorCommand
                 $item = $this->getElementFromFields($field);
                 $exp = $item['database'];
                 if ($exp !== '') {
-                    $exp = str_replace('NAME', "'".$field."'", $exp);
+                    $exp = str_replace('NAME', "'".$item['name']."'", $exp);
                     if (strpos($item['validation'], 'nullable') !== false) {
                         $exp.='->nullable()';
                     }
                     $parsed = $this->prefix("\$table->{$exp};", 3, false);
                 } else {
-                    $parsed = $this->prefix("\$table->('{$field}');", 3, false);
+                    $parsed = $this->prefix("\$table->('{$item['name']}');", 3, false);
                 }
 
                 if ($first) {


### PR DESCRIPTION
They are the same, when item was not found, because default inherits name from alias. They can be different thought when item was found.